### PR TITLE
Add higher-order reducer for including only specific actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ npm install --save redux-ignore
 ## API
 
 ```js
-import ignoreActions from 'redux-ignore';
+import ignoreActions, {filterActions} from 'redux-ignore';
+
 ignoreActions(reducer, [ARRAY_OF_ACTIONS])
 ignoreActions(reducer, (action) => !action.valid)
+
+filterActions(reducer, [ARRAY_OF_ACTIONS])
+filterActions(reducer, (action) => action.valid)
 ```
 
 
@@ -35,7 +39,7 @@ Firstly, import `redux-ignore`:
 // Redux utility functions
 import { combineReducers } from 'redux';
 // redux-ignore higher-order reducer
-import { ignoreActions } from 'redux-ignore';
+import ignoreActions from 'redux-ignore';
 ```
 
 Then, add `ignoreActions` to your reducer(s) like this:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save redux-ignore
 ## API
 
 ```js
-import ignoreActions, {filterActions} from 'redux-ignore';
+import { ignoreActions, filterActions } from 'redux-ignore';
 
 ignoreActions(reducer, [ARRAY_OF_ACTIONS])
 ignoreActions(reducer, (action) => !action.valid)
@@ -39,7 +39,7 @@ Firstly, import `redux-ignore`:
 // Redux utility functions
 import { combineReducers } from 'redux';
 // redux-ignore higher-order reducer
-import ignoreActions from 'redux-ignore';
+import { ignoreActions } from 'redux-ignore';
 ```
 
 Then, add `ignoreActions` to your reducer(s) like this:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Firstly, import `redux-ignore`:
 // Redux utility functions
 import { combineReducers } from 'redux';
 // redux-ignore higher-order reducer
-import ignoreActions from 'redux-ignore';
+import { ignoreActions } from 'redux-ignore';
 ```
 
 Then, add `ignoreActions` to your reducer(s) like this:
@@ -55,6 +55,20 @@ Alternatively, you can ignore actions via a predicate function:
 combineReducers({
   counter: ignoreActions(counter, (action) => action.type === INCREMENT_COUNTER)
 });
+```
+
+You can also use `filterActions` to only accept actions that are declared in an array, or that satisfy the predicate function:
+
+```js
+import { combineReducers } from 'redux';
+import { filterActions } from 'redux-ignore'; // pull in the filterActions function
+import { STAY_COOL, KEEP_CHILLIN } from './actions';
+
+combineReducers({
+  counter: filterActions(counter, (action) => action.type.match(/COUNTER$/)), // only run on actions that satisfy the regex
+  notACounter: filterActions(notACounter, [STAY_COOL, KEEP_CHILLIN]) // only run for these specific relaxing actions
+});
+
 ```
 
 ## What is this magic? How does it work?

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,6 @@ function createActionHandler (ignore) {
 export const ignoreActions = createActionHandler(true)
 export const filterActions = createActionHandler(false)
 
-export default ignoreActions
+export default { ignoreActions, filterActions }
 // /redux-ignore
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,6 @@ function createActionHandler (ignore) {
 export const ignoreActions = createActionHandler(true)
 export const filterActions = createActionHandler(false)
 
-export default { ignoreActions, filterActions }
+export default ignoreActions
 // /redux-ignore
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function createActionHandler (ignore) {
 }
 
 export const ignoreActions = createActionHandler(true)
-export const includeActions = createActionHandler(false)
+export const filterActions = createActionHandler(false)
 
 export default ignoreActions
 // /redux-ignore

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,25 @@
 import isFunction from 'lodash/lang/isFunction'
 
-// redux-ignore higher order reducer
-export default function ignoreActions (reducer, actions = []) {
-  let ignorePredicate = isFunction(actions)
-    ? actions
-    : (action) => actions.indexOf(action.type) >= 0
+function createActionHandler (ignore) {
+  // redux-ignore higher order reducer
+  return function handleAction (reducer, actions = []) {
+    const predicate = isFunction(actions)
+        ? actions
+        : (action) => actions.indexOf(action.type) >= 0
 
-  return (state, action) => {
-    if (!ignorePredicate(action)) {
-      return reducer(state, action)
+    return (state, action) => {
+      if (predicate(action)) {
+        return ignore ? state : reducer(state, action)
+      }
+
+      return ignore ? reducer(state, action) : state
     }
-
-    return state
   }
 }
+
+export const ignoreActions = createActionHandler(true)
+export const includeActions = createActionHandler(false)
+
+export default ignoreActions
 // /redux-ignore
+

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import {ignoreActions, includeActions} from '../src/index'
+import { ignoreActions, filterActions } from '../src/index'
 
 describe('ignoreActions()', () => {
   let reducer = (state, action) => {
@@ -50,7 +50,7 @@ describe('ignoreActions()', () => {
   })
 })
 
-describe('includeActions()', () => {
+describe('filterActions()', () => {
   let reducer = (state, action) => {
     switch (action.type) {
       case 'FOO':
@@ -63,38 +63,38 @@ describe('includeActions()', () => {
   }
 
   it('should include actions with specified types in array', () => {
-    let includingReducer = includeActions(reducer, ['BAR'])
+    let filteringReducer = filterActions(reducer, ['BAR'])
     let action = { type: 'BAR' }
 
     assert.equal(
-      includingReducer('testing', action),
+      filteringReducer('testing', action),
       'bar-state')
   })
 
   it('should exclude actions that do not have types in array', () => {
-    let includingReducer = includeActions(reducer, ['BAR'])
+    let filteringReducer = filterActions(reducer, ['BAR'])
     let action = { type: 'FOO' }
 
     assert.equal(
-      includingReducer('testing', action),
+      filteringReducer('testing', action),
       'testing')
   })
 
   it('should exclude all actions when no action types array is specified', () => {
-    let includingReducer = includeActions(reducer)
+    let filteringReducer = filterActions(reducer)
     let action = { type: 'BAZ' }
 
     assert.equal(
-      includingReducer('testing', action),
+      filteringReducer('testing', action),
       'testing')
   })
 
   it('should work with a predicate function for actions', () => {
-    let includingReducer = includeActions(reducer, (a) => a.valid)
+    let filteringReducer = filterActions(reducer, (a) => a.valid)
     let action = { type: 'BAR', valid: true }
 
     assert.equal(
-      includingReducer('testing', action),
+      filteringReducer('testing', action),
       'bar-state')
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import ignoreActions, { filterActions } from '../src/index'
+import { ignoreActions, filterActions } from '../src/index'
 
 let reducer = (state, action) => {
   switch (action.type) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { ignoreActions, filterActions } from '../src/index'
+import ignoreActions, { filterActions } from '../src/index'
 
 let reducer = (state, action) => {
   switch (action.type) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,18 +1,18 @@
 import assert from 'assert'
 import { ignoreActions, filterActions } from '../src/index'
 
-describe('ignoreActions()', () => {
-  let reducer = (state, action) => {
-    switch (action.type) {
-      case 'FOO':
-        return 'foo-state'
-      case 'BAR':
-        return 'bar-state'
-      default:
-        return 'default-state'
-    }
+let reducer = (state, action) => {
+  switch (action.type) {
+    case 'FOO':
+      return 'foo-state'
+    case 'BAR':
+      return 'bar-state'
+    default:
+      return 'default-state'
   }
+}
 
+describe('ignoreActions()', () => {
   it('should ignore actions with specified types in array', () => {
     let ignoringReducer = ignoreActions(reducer, ['BAR'])
     let action = { type: 'BAR' }
@@ -51,17 +51,6 @@ describe('ignoreActions()', () => {
 })
 
 describe('filterActions()', () => {
-  let reducer = (state, action) => {
-    switch (action.type) {
-      case 'FOO':
-        return 'foo-state'
-      case 'BAR':
-        return 'bar-state'
-      default:
-        return 'default-state'
-    }
-  }
-
   it('should include actions with specified types in array', () => {
     let filteringReducer = filterActions(reducer, ['BAR'])
     let action = { type: 'BAR' }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import ignoreActions from '../src/index'
+import {ignoreActions, includeActions} from '../src/index'
 
 describe('ignoreActions()', () => {
   let reducer = (state, action) => {
@@ -47,5 +47,54 @@ describe('ignoreActions()', () => {
     assert.equal(
       ignoringReducer('testing', action),
       'testing')
+  })
+})
+
+describe('includeActions()', () => {
+  let reducer = (state, action) => {
+    switch (action.type) {
+      case 'FOO':
+        return 'foo-state'
+      case 'BAR':
+        return 'bar-state'
+      default:
+        return 'default-state'
+    }
+  }
+
+  it('should include actions with specified types in array', () => {
+    let includingReducer = includeActions(reducer, ['BAR'])
+    let action = { type: 'BAR' }
+
+    assert.equal(
+      includingReducer('testing', action),
+      'bar-state')
+  })
+
+  it('should exclude actions that do not have types in array', () => {
+    let includingReducer = includeActions(reducer, ['BAR'])
+    let action = { type: 'FOO' }
+
+    assert.equal(
+      includingReducer('testing', action),
+      'testing')
+  })
+
+  it('should exclude all actions when no action types array is specified', () => {
+    let includingReducer = includeActions(reducer)
+    let action = { type: 'BAZ' }
+
+    assert.equal(
+      includingReducer('testing', action),
+      'testing')
+  })
+
+  it('should work with a predicate function for actions', () => {
+    let includingReducer = includeActions(reducer, (a) => a.valid)
+    let action = { type: 'BAR', valid: true }
+
+    assert.equal(
+      includingReducer('testing', action),
+      'bar-state')
   })
 })


### PR DESCRIPTION
I was curious about what it might look like to have a complementary function to use predicate arrays/functions to exclusively include specific actions, so I sketched this out. Might be useful in terms of expressiveness.

Tests can likely be slimmed/collapsed, but I wanted to pitch the idea.