### PR TITLE
UPDATE: default state value.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ function createActionHandler (ignore) {
         : (action) => actions.indexOf(action.type) >= 0
 
     return (state, action) => {
+      if (typeof state === 'undefined') state = {};
       if (predicate(action)) {
         return ignore ? state : reducer(state, action)
       }


### PR DESCRIPTION
Assign a blank object for state if it is undefined (Mostly on reducer initialization).