### PR TITLE
Undefined initial state

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "assert": "^1.3.0",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "eslint": "^2.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,9 @@ function createActionHandler (ignore) {
         ? actions
         : (action) => actions.indexOf(action.type) >= 0
 
-    return (state, action) => {
+    const initialState = reducer(undefined, {})
+
+    return (state = initialState, action) => {
       if (predicate(action)) {
         return ignore ? state : reducer(state, action)
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,4 +1,6 @@
 import assert from 'assert'
+import { createStore } from 'redux'
+
 import { ignoreActions, filterActions } from '../src/index'
 
 let reducer = (state, action) => {
@@ -85,5 +87,14 @@ describe('filterActions()', () => {
     assert.equal(
       filteringReducer('testing', action),
       'bar-state')
+  })
+
+  it('should return an initial state when a redux store is created', () => {
+    let filteringReducer = filterActions(reducer, ['BAR'])
+    let store = createStore(filteringReducer)
+
+    assert.equal(
+      store.getState(),
+      reducer(undefined, {}))
   })
 })


### PR DESCRIPTION
Closes #4, #6.

Bumps the babel-eslint dep so linting works with Babel 6, and CI won't fail.

Uses the handed-in reducer's return value from receiving an `undefined` state along with an empty object for an action. `{}` is a good stand-in for an initial Redux store dispatch as far as I can tell. 

We're basically pre-baking an initial state tree instead of letting the store do it on the first run.