### PR TITLE
npm ignore babelrc file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 src
 test
 coverage
+.babelrc


### PR DESCRIPTION
See here for use case:

https://github.com/gaearon/redux-thunk/issues/43
https://github.com/facebook/react-native/issues/4062

Having the `.babelrc` under the package directory breaks react-native's packager